### PR TITLE
clustering: parallelization of blocking

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,8 @@ matrix:
 install: source travis-install.sh
 
 script:
-    - python setup.py test
+    - python setup.py install
+    - py.test
     - pep257 beard
     - "sphinx-build -qnNW doc doc/_build/html"
 

--- a/examples/author_disambiguation.py
+++ b/examples/author_disambiguation.py
@@ -141,7 +141,8 @@ if __name__ == "__main__":
     block_clusterer = BlockClustering(
         blocking=blocking,
         base_estimator=ScipyHierarchicalClustering(affinity=affinity,
-                                                   method="complete"))
+                                                   method="complete"),
+        n_jobs=-1)
     block_clusterer.fit(X, y=y)
     labels = block_clusterer.labels_
 

--- a/setup.py
+++ b/setup.py
@@ -81,6 +81,7 @@ _keywords = [
 
 _install_requires = [
     "scipy>=0.14",
+    "joblib>=0.8.4",
     "numpy>=1.9",
     "scikit-learn>=0.15.2"
 ]


### PR DESCRIPTION
* Parallelizes `_fit` function in BlockClustering class.
  Each job takes care only about specific blocks.

* Introduces usage of joblib library.

Time performance (used `time.time` due to the usage of `multiprocessing`. `time.clock` measures only the time consumed by the main thread):
https://docs.google.com/spreadsheets/d/1mxxvpCxuwPhY4sVlk6wJL2copjNXsV34eMDOzBSFwPQ/edit?usp=sharing

TO DO/TO CONSIDER:
- [x] proper profiling. (not possible)
- [X] try dividing the input data before sending it to the job.  (implemented and attached)
- [X] test for number of jobs more than 1.