### PR TITLE
clustering: BlockClustering.labels_ as a property

### DIFF
--- a/beard/clustering/tests/test_blocking.py
+++ b/beard/clustering/tests/test_blocking.py
@@ -116,6 +116,16 @@ def test_partial_fit():
     assert_equal(paired_f_score(c1, c2), 1.0)
 
 
+def test_onthefly_labels():
+    clusterer = BlockClustering(
+        base_estimator=ScipyHierarchicalClustering(n_clusters=1,
+                                                   method="complete"))
+    clusterer.fit(X)
+    assert_array_equal([100], np.bincount(clusterer.labels_))
+    clusterer.clusterers_[0].set_params(n_clusters=4)
+    assert_array_equal([25, 25, 25, 25], np.bincount(clusterer.labels_))
+
+
 def test_predict():
     """Test predict."""
     clusterer = BlockClustering(blocking="precomputed",


### PR DESCRIPTION
This defines `labels_` as a property, thereby allowing on-the-fly changes if the underlying clusterers are modified. 

* [x] `labels_` as a property
* [x] tests