### PR TITLE
metrics: b^3 precision / recall / f-score

### DIFF
--- a/beard/metrics/__init__.py
+++ b/beard/metrics/__init__.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Beard.
-# Copyright (C) 2014 CERN.
+# Copyright (C) 2014, 2015 CERN.
 #
 # Beard is a free software; you can redistribute it and/or modify it
 # under the terms of the Revised BSD License; see LICENSE file for
@@ -9,6 +9,10 @@
 
 """Scoring metrics."""
 
+from .clustering import b3_precision_recall_fscore
+from .clustering import b3_precision_score
+from .clustering import b3_recall_score
+from .clustering import b3_f_score
 from .clustering import paired_precision_recall_fscore
 from .clustering import paired_precision_score
 from .clustering import paired_recall_score
@@ -17,7 +21,11 @@ from .text import jaro
 from .text import jaro_winkler
 from .text import levenshtein
 
-__all__ = ("paired_precision_recall_fscore",
+__all__ = ("b3_precision_recall_fscore",
+           "b3_precision_score",
+           "b3_recall_score",
+           "b3_f_score",
+           "paired_precision_recall_fscore",
            "paired_precision_score",
            "paired_recall_score",
            "paired_f_score",

--- a/beard/metrics/tests/test_clustering.py
+++ b/beard/metrics/tests/test_clustering.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Beard.
-# Copyright (C) 2014 CERN.
+# Copyright (C) 2014, 2015 CERN.
 #
 # Beard is a free software; you can redistribute it and/or modify it
 # under the terms of the Revised BSD License; see LICENSE file for
@@ -10,6 +10,7 @@
 """Test clustering evaluation metrics.
 
 .. codeauthor:: Evangelos Tzemis <evangelos.tzemis@cern.ch>
+.. codeauthor:: Gilles Louppe <g.louppe@cern.ch>
 
 """
 from __future__ import division
@@ -19,105 +20,200 @@ from numpy.testing import assert_equal
 from numpy.testing import assert_almost_equal
 import pytest
 
-from .. import clustering
+from ..clustering import b3_precision_recall_fscore
+from ..clustering import b3_precision_score
+from ..clustering import b3_recall_score
+from ..clustering import b3_f_score
+from ..clustering import paired_precision_recall_fscore
+from ..clustering import paired_precision_score
+from ..clustering import paired_recall_score
+from ..clustering import paired_f_score
+from ..clustering import _cluster_samples
+from ..clustering import _general_merge_distance
 
 
-def test_precision_recall_fscore():
-    """Test the results of precission_recall_fscore."""
+def test_b3_precision_recall_fscore():
+    """Test the results of b3_precision_recall_fscore."""
     # test for the border case where score maximum
     y = [1, 2, 1, 3, 2, 4, 5, 4]
-    assert_equal(clustering.paired_precision_recall_fscore(y, y), (1, 1, 1))
+    assert_equal(b3_precision_recall_fscore(y, y), (1, 1, 1))
 
-    # test for the border case where score minimum
-    y_true = [1, 2, 1, 3, 2, 4, 5, 4]
-    y_pred = [1, 1, 2, 2, 3, 3, 4, 4]
-    assert_equal(clustering.paired_precision_recall_fscore(y_true, y_pred),
-                 (0, 0, 0))
-
-    # test error raise when labels_true is empty
-    with pytest.raises(ValueError):
-        clustering.paired_precision_recall_fscore(y, [])
-
-    # test error raise when labels_pred is empty
-    with pytest.raises(ValueError):
-        clustering.paired_precision_recall_fscore([], y)
-
-    # test error raise when both inputs are empty
-    with pytest.raises(ValueError):
-        clustering.paired_precision_recall_fscore([], [])
+    # test for border case when predicting singletons
+    y_true = [1, 1, 2, 2]
+    y_pred = [1, 2, 3, 4]
+    assert_equal(b3_precision_recall_fscore(y_true, y_pred), (1, 0.5, 2 / 3))
 
 
-def test_cluster_invariability():
-    """Test that computed values are cluster invariant."""
+def test_b3_precision_score():
+    """Test the returned results of b3_precision_score."""
+    y_true = [1, 1, 2, 2, 3, 4, 5]
+    y_pred = [1, 2, 2, 2, 3, 4, 5]
+    assert_almost_equal(b3_precision_score(y_true, y_pred), 17 / 21)
+
+    y_true = [1, 1, 1, 4, 5, 5, 0, 4]
+    y_pred = [1, 1, 1, 1, 5, 5, 6, 7]
+    assert_equal(b3_precision_score(y_true, y_pred), 13 / 16)
+
+    # test for the trivial maximum case
+    assert_equal(b3_precision_score(y_true, y_true), 1)
+
+
+def test_b3_recall_score():
+    """Test the returned results of b3_recall_score."""
+    y_true = [1, 1, 2, 2, 3, 4, 5]
+    y_pred = [1, 2, 2, 2, 3, 4, 5]
+    assert_almost_equal(b3_recall_score(y_true, y_pred), 6 / 7)
+
+    y_true = [1, 1, 1, 4, 5, 5, 0, 4]
+    y_pred = [1, 1, 1, 1, 5, 5, 6, 7]
+    assert_equal(b3_recall_score(y_true, y_pred), 7 / 8)
+
+    # test for the trivial maximum case
+    assert_equal(b3_recall_score(y_true, y_true), 1)
+
+
+def test_b3_f_score():
+    """Test the returned results of b3_f_score."""
+    y_true = [1, 1, 2, 2, 3, 4, 5]
+    y_pred = [1, 2, 2, 2, 3, 4, 5]
+    desired_output = 2 * (17 / 21) * (6 / 7) / (17 / 21 + 6 / 7)
+    assert_almost_equal(b3_f_score(y_true, y_pred), desired_output)
+
+    y_true = [1, 1, 1, 4, 5, 5, 0, 4]
+    y_pred = [1, 1, 1, 1, 5, 5, 6, 7]
+    desired_output = 2 * (13 / 16) * (7 / 8) / (13 / 16 + 7 / 8)
+    assert_almost_equal(b3_f_score(y_true, y_pred),  desired_output)
+
+    # test for the trivial maximum case
+    assert_equal(b3_f_score(y_true, y_true), 1)
+
+
+def test_b3_label_invariability():
+    """Test that paired P/R/F values are label invariant."""
     y = [1, 2, 1, 3, 2, 4, 5, 4]
     y_prime_invariant = [3, 6, 6, 5, 6, 2, 4, 2]
     y_prime = [2, 3, 3, 4, 3, 5, 1, 5]
-    assert_equal(clustering.paired_precision_recall_fscore(y, y_prime),
-                 clustering.paired_precision_recall_fscore(y,
-                                                           y_prime_invariant))
+    assert_equal(b3_precision_recall_fscore(y, y_prime),
+                 b3_precision_recall_fscore(y, y_prime_invariant))
 
 
-def test_raise_valueError():
-    """Test the raise of the ValueError exception."""
+def test_b3_raise_error():
+    """Test the raise of the ValueError exception for paired P/R/F."""
     y = np.array([1, 2, 1, 3, 2, 4, 5, 4])
 
     # test raise when not 1d shape
     y = y.reshape(2, 4)
     with pytest.raises(ValueError):
-        clustering.paired_precision_recall_fscore(y, y)
+        b3_precision_recall_fscore(y, y)
 
     # test raise when different size of elements
     y = y.reshape(8, 1)
     with pytest.raises(ValueError):
-        clustering.paired_precision_recall_fscore(y[1:], y[2:])
+        b3_precision_recall_fscore(y[1:], y[2:])
+
+    # test error raise when labels_true is empty
+    with pytest.raises(ValueError):
+        b3_precision_recall_fscore(y, [])
+
+    # test error raise when labels_pred is empty
+    with pytest.raises(ValueError):
+        b3_precision_recall_fscore([], y)
+
+    # test error raise when both inputs are empty
+    with pytest.raises(ValueError):
+        b3_precision_recall_fscore([], [])
 
 
-def test_precision_score():
-    """Test the returned results of precision_score."""
+def test_paired_precision_recall_fscore():
+    """Test the results of paired_precision_recall_fscore."""
+    # test for border case where score is maximum
+    y = [1, 2, 1, 3, 2, 4, 5, 4]
+    assert_equal(paired_precision_recall_fscore(y, y), (1, 1, 1))
+
+    # test for border case where score is minimum
+    y_true = [1, 2, 1, 3, 2, 4, 5, 4]
+    y_pred = [1, 1, 2, 2, 3, 3, 4, 4]
+    assert_equal(paired_precision_recall_fscore(y_true, y_pred), (0, 0, 0))
+
+
+def test_paired_precision_score():
+    """Test the returned results of paired_precision_score."""
     y_true = [1, 1, 2, 2, 3, 4, 5]
     y_pred = [1, 2, 2, 2, 3, 4, 5]
-    assert_almost_equal(clustering.paired_precision_score(y_true, y_pred),
-                        1.0 / 3)
+    assert_almost_equal(paired_precision_score(y_true, y_pred), 1 / 3)
 
     y_true = [1, 1, 1, 4, 5, 5, 0, 4]
     y_pred = [1, 1, 1, 1, 5, 5, 6, 7]
-    assert_equal(clustering.paired_precision_score(y_true, y_pred), 4.0/7.0)
+    assert_equal(paired_precision_score(y_true, y_pred), 4 / 7)
 
     # test for the trivial maximum case
-    assert_equal(clustering.paired_precision_score(y_true, y_true), 1)
+    assert_equal(paired_precision_score(y_true, y_true), 1)
 
 
-def test_recall_score():
-    """Test the returned results of recall_score."""
+def test_paired_recall_score():
+    """Test the returned results of paired_recall_score."""
     y_true = [1, 1, 2, 2, 3, 4, 5]
     y_pred = [1, 2, 2, 2, 3, 4, 5]
-    assert_almost_equal(clustering.paired_recall_score(y_true, y_pred),
-                        0.5)
+    assert_almost_equal(paired_recall_score(y_true, y_pred), 0.5)
 
     y_true = [1, 1, 1, 4, 5, 5, 0, 4]
     y_pred = [1, 1, 1, 1, 5, 5, 6, 7]
-    assert_equal(clustering.paired_recall_score(y_true, y_pred), 4.0/5.0)
+    assert_equal(paired_recall_score(y_true, y_pred), 4 / 5)
 
     # test for the trivial maximum case
-    assert_equal(clustering.paired_recall_score(y_true, y_true), 1)
+    assert_equal(paired_recall_score(y_true, y_true), 1)
 
 
-def test_f_score():
-    """Test the returned results of F-score."""
+def test_paired_f_score():
+    """Test the returned results of paired_f_score."""
     y_true = [1, 1, 2, 2, 3, 4, 5]
     y_pred = [1, 2, 2, 2, 3, 4, 5]
-    desired_output = 2*(1.0/3)*0.5/((1.0/3)+0.5)
-    assert_almost_equal(clustering.paired_f_score(y_true, y_pred),
-                        desired_output)
+    desired_output = 2 * (1 / 3) * 0.5 / (1 / 3 + 0.5)
+    assert_almost_equal(paired_f_score(y_true, y_pred), desired_output)
 
     y_true = [1, 1, 1, 4, 5, 5, 0, 4]
     y_pred = [1, 1, 1, 1, 5, 5, 6, 7]
-    desired_output = 2*(4.0/7.0)*(4.0/5.0)/(4.0/7.0 + 4.0/5.0)
-    assert_almost_equal(clustering.paired_f_score(y_true, y_pred),
-                        desired_output)
+    desired_output = 2 * (4 / 7) * (4 / 5) / (4 / 7 + 4 / 5)
+    assert_almost_equal(paired_f_score(y_true, y_pred), desired_output)
 
     # test for the trivial maximum case
-    assert_equal(clustering.paired_f_score(y_true, y_true), 1)
+    assert_equal(paired_f_score(y_true, y_true), 1)
+
+
+def test_paired_label_invariability():
+    """Test that paired P/R/F values are label invariant."""
+    y = [1, 2, 1, 3, 2, 4, 5, 4]
+    y_prime_invariant = [3, 6, 6, 5, 6, 2, 4, 2]
+    y_prime = [2, 3, 3, 4, 3, 5, 1, 5]
+    assert_equal(paired_precision_recall_fscore(y, y_prime),
+                 paired_precision_recall_fscore(y, y_prime_invariant))
+
+
+def test_paired_raise_error():
+    """Test the raise of the ValueError exception for paired P/R/F."""
+    y = np.array([1, 2, 1, 3, 2, 4, 5, 4])
+
+    # test raise when not 1d shape
+    y = y.reshape(2, 4)
+    with pytest.raises(ValueError):
+        paired_precision_recall_fscore(y, y)
+
+    # test raise when different size of elements
+    y = y.reshape(8, 1)
+    with pytest.raises(ValueError):
+        paired_precision_recall_fscore(y[1:], y[2:])
+
+    # test error raise when labels_true is empty
+    with pytest.raises(ValueError):
+        paired_precision_recall_fscore(y, [])
+
+    # test error raise when labels_pred is empty
+    with pytest.raises(ValueError):
+        paired_precision_recall_fscore([], y)
+
+    # test error raise when both inputs are empty
+    with pytest.raises(ValueError):
+        paired_precision_recall_fscore([], [])
 
 
 def test_cluster_samples():
@@ -125,7 +221,7 @@ def test_cluster_samples():
     y = [1, 2, 1, 3, 2, 4, 5, 4]
     cls_true = {1: [0, 2], 2: [1, 4], 3: [3], 4: [5, 7], 5: [6]}
 
-    assert_equal(cls_true, clustering._cluster_samples(y))
+    assert_equal(cls_true, _cluster_samples(y))
 
 
 def test_general_merge_distance():
@@ -134,13 +230,13 @@ def test_general_merge_distance():
     y_pred = [1, 1, 1, 2, 2, 2]
 
     # test for trivial case
-    assert_equal(clustering._general_merge_distance(y_true, y_true), 0)
+    assert_equal(_general_merge_distance(y_true, y_true), 0)
 
     # test that fs and fm has effect on result
-    zero_res = clustering._general_merge_distance(y_true, y_pred,
-                                                  fm=lambda x, y: 0,
-                                                  fs=lambda x, y: 0)
+    zero_res = _general_merge_distance(y_true, y_pred,
+                                       fm=lambda x, y: 0,
+                                       fs=lambda x, y: 0)
     assert_equal(zero_res, 0)
 
     # test for default functions
-    assert_equal(clustering._general_merge_distance(y_true, y_pred), 4.0)
+    assert_equal(_general_merge_distance(y_true, y_pred), 4)


### PR DESCRIPTION
Implementation of B^3 precision, recall and F-score metrics. These variants have the advantage of not being sensitive to the quadratic effect of cluster size (in contrast with with paired variants, which suffer from this).

* [x] Implementation
* [x] Tests
* [x] Documentation

This addresses #21.