### PR TITLE
metrics: bug fix in jaro metric

### DIFF
--- a/beard/metrics/tests/test_text.py
+++ b/beard/metrics/tests/test_text.py
@@ -73,7 +73,8 @@ def test_jaro_matching(s1, s2, match):
                    ('DWAYNE', 'DUANE', 0.822),
                    ('ABCDEFG', 'ABCDEFG', 1.0),
                    ('', 'ABCDEFG', 0.0),
-                   ('ABCDEFG', 'HIGKLMN', 0.0)))
+                   ('ABCDEFG', 'HIGKLMN', 0.0),
+                   ('apple', 'apple', 1.0)))
 def test_jaro(s1, s2, match):
     """Test jaro_similarity_metric behaviour."""
     assert_almost_equal(jaro(s1, s2), match, 3)

--- a/beard/metrics/text.py
+++ b/beard/metrics/text.py
@@ -77,17 +77,17 @@ def _jaro_matching(s1, s2):
                     if j not in s2_matched_positions:
                         matches += 1
                         s2_matched_positions.append(j)
-                    s1_matching_letters.append((i, letter))
-                    break
+                        s1_matching_letters.append((i, letter))
+                        break
 
     for letter, (s1_positions, s2_positions) in letters_cache.items():
         for j in s2_positions:
             for i in s1_positions:
-                if i - H <= j <= i + H:
+                if j - H <= i <= j + H:
                     if i not in s1_matched_positions:
                         s1_matched_positions.append(i)
-                    s2_matching_letters.append((j, letter))
-                    break
+                        s2_matching_letters.append((j, letter))
+                        break
 
     s1_matching_letters.sort()
     s2_matching_letters.sort()


### PR DESCRIPTION
Wrong computation of words that contain double letters in a sequence.

Signed-off-by: Petros Ioannidis <petros.ioannidis91@gmail.com>